### PR TITLE
Fix encoding

### DIFF
--- a/uu.go
+++ b/uu.go
@@ -123,7 +123,7 @@ func EncodeBlock(data []byte) ([]byte, error) {
 			break
 		}
 		out = append(out, byte(n+32)) // length
-		out = append(out, encoding.EncodeToString(inputBlock)...)
+		out = append(out, encoding.EncodeToString(inputBlock[:n])...)
 		out = append(out, '\n')
 	}
 	return out, nil

--- a/uu.go
+++ b/uu.go
@@ -15,7 +15,7 @@ const (
 )
 
 var (
-	encoding = NewEncoding(UUAlphabet)
+	encoding = NewEncoding(UUAlphabet).WithPadding(NoPadding)
 )
 
 // Decoded holds result from uuencoded decode

--- a/uu_test.go
+++ b/uu_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 
 	fuzz "github.com/google/gofuzz"
+	"github.com/leanovate/gopter"
+	"github.com/leanovate/gopter/gen"
+	"github.com/leanovate/gopter/prop"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -125,4 +128,25 @@ func TestFuzzDecodeLine(t *testing.T) {
 		f.Fuzz(&rnd)
 		DecodeLine(rnd)
 	}
+}
+
+func TestRountTrip(t *testing.T) {
+	props := gopter.NewProperties(gopter.DefaultTestParameters())
+	props.Property("UU Roundtrip", prop.ForAll(
+		func(v string) bool {
+			filename := "<data>"
+			mode := "0666"
+			encoded, err := Encode([]byte(v), filename, mode)
+			if err != nil {
+				return false
+			}
+			decoded, err := Decode(encoded)
+			if err != nil {
+				return false
+			}
+			return v == string(decoded.Data) && decoded.Filename == filename && decoded.Mode == mode
+		},
+		gen.AnyString(),
+	))
+	props.TestingRun(t)
 }

--- a/uu_test.go
+++ b/uu_test.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	fuzzRounds   = 10000
-	encodedLine1 = `K5&AE('%U:6-K(&)R;W=N(&9O>"!J=6UP<R!O=F5R('1H92!L87IY(&1O9P  `
+	encodedLine1 = `K5&AE('%U:6-K(&)R;W=N(&9O>"!J=6UP<R!O=F5R('1H92!L87IY(&1O9P`
 	mode1        = "644"
 	file1        = `stuff.txt`
 	encoded1     = `begin ` + mode1 + ` ` + file1 + "\n" +


### PR DESCRIPTION
Removes padding and avoids encoding garbage beyond end-of-read input buffer.

Also adds gopter-based roundtrip test that generates random data to encode/decode roundtrip each test is run.

fixes #3 